### PR TITLE
fix cefr-no-file word duplication

### DIFF
--- a/src/app/blog/5/page.js
+++ b/src/app/blog/5/page.js
@@ -35,16 +35,19 @@ export default function Home() {
       .then((csvText) => {
         Papa.parse(csvText, {
           complete: (result) => {
-            const parsedWords = result.data.map((row) => {
-              if (!row.headword || !row.CEFR) {
-                console.warn("Invalid row:", row); // Log the problematic rows
-              }
-              return {
-                headword: row.headword ? row.headword.trim() : "",
-                CEFR: row.CEFR ? row.CEFR.trim().toUpperCase() : "",
-              };
-            });
-            setWords(parsedWords);
+						const parsedWordsMap = new Map();
+						result.data.forEach((row) => {
+							if (!row.headword || !row.CEFR) {
+								console.warn("Invalid row:", row); // Log the problematic rows
+                return;
+							}
+							parsedWordsMap.set(row.headword, {
+								headword: row.headword.trim(),
+								CEFR: row.CEFR.trim().toUpperCase(),
+							});
+						});
+
+						setWords(Array.from(parsedWordsMap.values()));
           },
           header: true,
         });
@@ -81,9 +84,9 @@ export default function Home() {
 
     if (untestedWords.length === 0) return; // No more untested words
 
-    // Pick a random word from the filtered words
-    const randomIndex = Math.floor(Math.random() * filteredWords.length);
-    const word = filteredWords[randomIndex];
+		// Pick a random word from the untested words
+		const randomIndex = Math.floor(Math.random() * untestedWords.length);
+		const word = untestedWords[randomIndex];
 
     setRandomWord(word);
     setTestedWords((prev) => [...prev, word]); // Increment the number of tested words


### PR DESCRIPTION
* Removes duplicated words from `csv` file retrieved results;
* Gets next word from `untestedWords` array to prevent duplication